### PR TITLE
Fix long sequence slicing to maxlen

### DIFF
--- a/app/src/main/java/com/ml/quaterion/sarcaso/EmbeddingBuilder.kt
+++ b/app/src/main/java/com/ml/quaterion/sarcaso/EmbeddingBuilder.kt
@@ -70,7 +70,7 @@ class EmbeddingBuilder  {
     fun padSequence ( sequence : Array<DoubleArray> ) : Array<DoubleArray> {
         val maxlen = this.maxlen
         if ( sequence.size > maxlen!!) {
-            return sequence.sliceArray( 0..maxlen )
+            return sequence.sliceArray( 0 until maxlen )
         }
         else if ( sequence.size < maxlen ) {
             val array = ArrayList<DoubleArray>()


### PR DESCRIPTION
Fixes that sequences longer than maxlen are sliced to length maxlen+1 instead of maxlen, which causes errors right now for long inputs